### PR TITLE
Fix pagination layout

### DIFF
--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { DynamicLink } from "./dynamic-link";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
+import { DynamicLink } from "./dynamic-link";
 
 interface NextPrevPageProps {
   title: string;
@@ -20,7 +20,7 @@ export function Pagination({ prevPage, nextPage }: PaginationProps) {
           <div className="group relative block cursor-pointer p-4 text-left transition-all">
             <span className="pl-10 text-sm uppercase opacity-50">Previous</span>
             <h5 className="pl m-0 flex items-center text-base leading-[1.3] text-brand-secondary transition-all duration-150 ease-out group-hover:text-orange-500 md:text-xl">
-              <MdChevronLeft className="ml-2 size-7 fill-gray-400 transition-all duration-150 ease-out group-hover:fill-orange-500"/>
+              <MdChevronLeft className="ml-2 size-7 fill-gray-400 transition-all duration-150 ease-out group-hover:fill-orange-500" />
               {prevPage.title}
             </h5>
           </div>
@@ -36,8 +36,7 @@ export function Pagination({ prevPage, nextPage }: PaginationProps) {
             </span>
             <h5 className="m-0 flex items-center justify-end text-base leading-[1.3] text-brand-secondary transition-all duration-150 ease-out group-hover:text-orange-500 md:text-xl">
               {nextPage.title}
-              <MdChevronRight className="ml-2 size-7 fill-gray-400 transition-all duration-150 ease-out group-hover:fill-orange-500"/>
-              
+              <MdChevronRight className="ml-2 size-7 fill-gray-400 transition-all duration-150 ease-out group-hover:fill-orange-500" />
             </h5>
           </div>
         </DynamicLink>

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { DynamicLink } from "./dynamic-link";
+import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 
 interface NextPrevPageProps {
   title: string;
@@ -13,25 +14,21 @@ interface PaginationProps {
 
 export function Pagination({ prevPage, nextPage }: PaginationProps) {
   return (
-    <div className="mt-8 grid grid-cols-2 gap-4">
-      {prevPage?.slug && (
+    <div className="flex justify-between mt-12 py-4  rounded-lg gap-4 overflow-hidden">
+      {prevPage?.slug ? (
         <DynamicLink href={prevPage.slug} passHref>
           <div className="group relative block cursor-pointer p-4 text-left transition-all">
             <span className="pl-10 text-sm uppercase opacity-50">Previous</span>
             <h5 className="pl m-0 flex items-center text-base leading-[1.3] text-brand-secondary transition-all duration-150 ease-out group-hover:text-orange-500 md:text-xl">
-              <svg
-                viewBox="0 0 32 32"
-                className="mr-2 size-7 rotate-180 fill-gray-400 transition-all duration-150 ease-out group-hover:fill-orange-500"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M11 24.792L12.2654 26L21.4773 17.2061C22.1747 16.5403 22.1737 15.4588 21.4773 14.7939L12.2654 6L11 7.20799L20.2099 16L11 24.792Z" />
-              </svg>
+              <MdChevronLeft className="ml-2 size-7 fill-gray-400 transition-all duration-150 ease-out group-hover:fill-orange-500"/>
               {prevPage.title}
             </h5>
           </div>
         </DynamicLink>
+      ) : (
+        <div />
       )}
-      {nextPage?.slug && (
+      {nextPage?.slug ? (
         <DynamicLink href={nextPage.slug} passHref>
           <div className="group relative col-start-2 block cursor-pointer p-4 text-right transition-all">
             <span className="pr-6 text-sm uppercase opacity-50 md:pr-10">
@@ -39,16 +36,13 @@ export function Pagination({ prevPage, nextPage }: PaginationProps) {
             </span>
             <h5 className="m-0 flex items-center justify-end text-base leading-[1.3] text-brand-secondary transition-all duration-150 ease-out group-hover:text-orange-500 md:text-xl">
               {nextPage.title}
-              <svg
-                viewBox="0 0 32 32"
-                className="ml-2 size-7 fill-gray-400 transition-all duration-150 ease-out group-hover:fill-orange-500"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="M11 24.792L12.2654 26L21.4773 17.2061C22.1747 16.5403 22.1737 15.4588 21.4773 14.7939L12.2654 6L11 7.20799L20.2099 16L11 24.792Z" />
-              </svg>
+              <MdChevronRight className="ml-2 size-7 fill-gray-400 transition-all duration-150 ease-out group-hover:fill-orange-500"/>
+              
             </h5>
           </div>
         </DynamicLink>
+      ) : (
+        <div />
       )}
     </div>
   );


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/3526

<img width="1289" alt="Screenshot 2025-06-06 at 9 08 25 am" src="https://github.com/user-attachments/assets/84c5e817-c88d-4791-8f7e-379c891d961e" />

**Figure: Before - next pagination would sit on the left**

<img width="1323" alt="Screenshot 2025-06-06 at 9 06 32 am" src="https://github.com/user-attachments/assets/071c3349-0c58-47db-81df-430ecefd59f4" />

**Figure: After - next pagination always sits on the right**