### PR TITLE
Fix for when auto-save creates mismatched char's to user inputted text

### DIFF
--- a/content/docs/components/code-blocks.mdx
+++ b/content/docs/components/code-blocks.mdx
@@ -1,17 +1,17 @@
 ---
 title: Code Blocks
-last_edited: '2025-05-26T00:53:57.452Z'
+last_edited: '2025-06-05T23:55:15.658Z'
 next: ''
 previous: ''
 ---
 
-TinaDocs supports both inline code snippets and fenced code blocks, letting you document examples, commands, and source code with clarity and flexibility. 
+TinaDocs supports both inline code snippets and fenced code blocks, letting you document examples, commands, and source code with clarity and flexibility.
 
 ## Inline Code
 
 Using a singular backtick we can wrap small bits of code as a code\_block
 
-Example: Use npm run dev to start the local server
+Example: Use `npm run dev` to start the local server
 
 ## Fenced Code Blocks
 
@@ -49,5 +49,9 @@ console.log('Junk Code');
 console.log('Focused Code'); // [!code focus]
 console.log('More hidden code');
 
-It uses "[!code focus]" in a comment after the code 
+It uses "[!code focus]" in a comment after the code
 ```
+
+## Tabbed Code Blocks
+
+<queryResponseTabs response="const LLAMAS = '100';" query="const CONTENT_MANAGEMENT = 'Optimized';" />

--- a/src/components/tina-markdown/standard-elements/code-block/code-block.tsx
+++ b/src/components/tina-markdown/standard-elements/code-block/code-block.tsx
@@ -24,25 +24,33 @@ export function CodeBlock({
     let isMounted = true;
 
     const load = async () => {
+      // Guard clause to prevent processing undefined/null/empty values - shiki will throw an error if the value is not a string as it tries to .split all values
+      if (!value || typeof value !== "string") {
+        if (isMounted) setHtml("");
+        return;
+      }
+
       const highlighter = await createHighlighter({
         themes: ["night-owl"],
         langs: [lang],
       });
 
-      const code = await highlighter.codeToHtml(value, {
-        lang,
-        theme: "night-owl",
-        transformers: [
-          transformerNotationDiff({ matchAlgorithm: "v3" }),
-          transformerNotationHighlight({ matchAlgorithm: "v3" }),
-          transformerNotationFocus({ matchAlgorithm: "v3" }),
-        ],
-        meta: {
-          showLineNumbers: true,
-        },
-      });
+      if (highlighter) {
+        const code = await highlighter?.codeToHtml(value, {
+          lang,
+          theme: "night-owl",
+          transformers: [
+            transformerNotationDiff({ matchAlgorithm: "v3" }),
+            transformerNotationHighlight({ matchAlgorithm: "v3" }),
+            transformerNotationFocus({ matchAlgorithm: "v3" }),
+          ],
+          meta: {
+            showLineNumbers: true,
+          },
+        });
 
-      if (isMounted) setHtml(code);
+        if (isMounted) setHtml(code);
+      }
     };
 
     load();


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/3528 

**Changes**
- [ ] Fixed mismatch between tina value and autocompleted text
- [ ] Marginal Increase debounce time for more smooth editing
- [ ] Updated content to add the tabbed code block 
- [ ] Added null check to mitigate errors thrown by shiki when text is null and shiki tries to .split it 