### PR TITLE
Fix Tina editing for titles 

### DIFF
--- a/src/app/docs/[...slug]/index.tsx
+++ b/src/app/docs/[...slug]/index.tsx
@@ -39,7 +39,7 @@ export default function Document({ props, tinaProps }) {
       >
         <div className="flex flex-col-reverse lg:flex-row lg:items-center justify-between w-full gap-2">
           <h1
-            className="brand-primary-gradient py-4 font-heading text-4xl"
+            className="brand-primary-gradient my-4 font-heading text-4xl"
             data-tina-field={tinaField(documentationData, "title")}
             data-pagefind-meta="title"
           >
@@ -51,7 +51,7 @@ export default function Document({ props, tinaProps }) {
         <div
           ref={contentRef}
           data-tina-field={tinaField(documentationData, "body")}
-          className="pt-4 font-body font-light leading-normal tracking-normal"
+          className="mt-4 font-body font-light leading-normal tracking-normal"
         >
           <TinaMarkdown
             content={documentationData?.body}


### PR DESCRIPTION
As per https://github.com/tinacms/tina.io/issues/3523

<img width="941" alt="Screenshot 2025-06-06 at 10 07 15 am" src="https://github.com/user-attachments/assets/cec93b8e-80ff-4786-ae0f-91f77bb09b82" />

**Figure: Before - TinaField bugged below, because of padding**

<img width="926" alt="Screenshot 2025-06-06 at 10 11 56 am" src="https://github.com/user-attachments/assets/f0b1491a-9cf1-4738-92a5-ae9709856d25" />

**Figure: After - TinaField not bugged, changed padding to margin**