### PR TITLE
Optimize gql query for nav bar data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,7 +67,7 @@ const Content = ({ children }: { children?: React.ReactNode }) => (
 const DocsMenu = async ({ children }: { children?: React.ReactNode }) => {
   // Fetch navigation data that will be shared across all docs pages
 
-  const navigationData = await client.queries.navigationBar({
+  const navigationData = await client.queries.minimisedNavigationBarFetch({
     relativePath: "docs-navigation-bar.json",
   });
 

--- a/src/app/tina-client.tsx
+++ b/src/app/tina-client.tsx
@@ -30,7 +30,7 @@ export function TinaClient<T>({ props, Component }: TinaClientProps<T>) {
     variables: props.variables,
     data: props.data,
     experimental___selectFormByFormId() {
-      return props.forceExperimental;
+      return `content/docs/${props.forceExperimental}`;
     },
   });
 

--- a/tina/queries/post.gql
+++ b/tina/queries/post.gql
@@ -38,7 +38,6 @@ fragment MinimisedNavigationBarParts on NavigationBar {
                             last_edited
                             auto_generated
                             tocIsHidden
-                            
                           }
                           ... on Document {
                             _sys {
@@ -71,7 +70,6 @@ fragment MinimisedNavigationBarParts on NavigationBar {
                         last_edited
                         auto_generated
                         tocIsHidden
-                        
                       }
                       ... on Document {
                         _sys {
@@ -104,7 +102,6 @@ fragment MinimisedNavigationBarParts on NavigationBar {
                     last_edited
                     auto_generated
                     tocIsHidden
-                    
                   }
                   ... on Document {
                     _sys {
@@ -137,7 +134,6 @@ fragment MinimisedNavigationBarParts on NavigationBar {
                 last_edited
                 auto_generated
                 tocIsHidden
-                
               }
               ... on Document {
                 _sys {
@@ -179,7 +175,6 @@ fragment MinimisedNavigationBarParts on NavigationBar {
                   last_edited
                   auto_generated
                   tocIsHidden
-                  
                 }
                 ... on Document {
                   _sys {

--- a/tina/queries/post.gql
+++ b/tina/queries/post.gql
@@ -1,0 +1,239 @@
+fragment MinimisedNavigationBarParts on NavigationBar {
+  __typename
+  lightModeLogo
+  darkModeLogo
+  tabs {
+    __typename
+    ... on NavigationBarTabsDocsTab {
+      title
+      supermenuGroup {
+        __typename
+        title
+        items {
+          __typename
+          ... on NavigationBarTabsDocsTabSupermenuGroupItemsItems {
+            title
+            items {
+              __typename
+              ... on NavigationBarTabsDocsTabSupermenuGroupItemsItemsItemsItems {
+                title
+                items {
+                  __typename
+                  ... on NavigationBarTabsDocsTabSupermenuGroupItemsItemsItemsItemsItemsItems {
+                    title
+                    items {
+                      __typename
+                      ... on NavigationBarTabsDocsTabSupermenuGroupItemsItemsItemsItemsItemsItemsItemsItem {
+                        slug {
+                          ... on Docs {
+                            __typename
+                            seo {
+                              __typename
+                              title
+                              description
+                              canonicalUrl
+                              ogImage
+                            }
+                            title
+                            last_edited
+                            auto_generated
+                            tocIsHidden
+                            
+                          }
+                          ... on Document {
+                            _sys {
+                              filename
+                              basename
+                              hasReferences
+                              breadcrumbs
+                              path
+                              relativePath
+                              extension
+                            }
+                            id
+                          }
+                        }
+                      }
+                    }
+                  }
+                  ... on NavigationBarTabsDocsTabSupermenuGroupItemsItemsItemsItemsItemsItem {
+                    slug {
+                      ... on Docs {
+                        __typename
+                        seo {
+                          __typename
+                          title
+                          description
+                          canonicalUrl
+                          ogImage
+                        }
+                        title
+                        last_edited
+                        auto_generated
+                        tocIsHidden
+                        
+                      }
+                      ... on Document {
+                        _sys {
+                          filename
+                          basename
+                          hasReferences
+                          breadcrumbs
+                          path
+                          relativePath
+                          extension
+                        }
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+              ... on NavigationBarTabsDocsTabSupermenuGroupItemsItemsItemsItem {
+                slug {
+                  ... on Docs {
+                    __typename
+                    seo {
+                      __typename
+                      title
+                      description
+                      canonicalUrl
+                      ogImage
+                    }
+                    title
+                    last_edited
+                    auto_generated
+                    tocIsHidden
+                    
+                  }
+                  ... on Document {
+                    _sys {
+                      filename
+                      basename
+                      hasReferences
+                      breadcrumbs
+                      path
+                      relativePath
+                      extension
+                    }
+                    id
+                  }
+                }
+              }
+            }
+          }
+          ... on NavigationBarTabsDocsTabSupermenuGroupItemsItem {
+            slug {
+              ... on Docs {
+                __typename
+                seo {
+                  __typename
+                  title
+                  description
+                  canonicalUrl
+                  ogImage
+                }
+                title
+                last_edited
+                auto_generated
+                tocIsHidden
+                
+              }
+              ... on Document {
+                _sys {
+                  filename
+                  basename
+                  hasReferences
+                  breadcrumbs
+                  path
+                  relativePath
+                  extension
+                }
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    ... on NavigationBarTabsApiTab {
+      title
+      supermenuGroup {
+        __typename
+        ... on NavigationBarTabsApiTabSupermenuGroupDocumentSubMenu {
+          title
+          items {
+            __typename
+            ... on NavigationBarTabsApiTabSupermenuGroupDocumentSubMenuItemsItem {
+              slug {
+                ... on Docs {
+                  __typename
+                  seo {
+                    __typename
+                    title
+                    description
+                    canonicalUrl
+                    ogImage
+                  }
+                  title
+                  last_edited
+                  auto_generated
+                  tocIsHidden
+                  
+                }
+                ... on Document {
+                  _sys {
+                    filename
+                    basename
+                    hasReferences
+                    breadcrumbs
+                    path
+                    relativePath
+                    extension
+                  }
+                  id
+                }
+              }
+            }
+          }
+        }
+        ... on NavigationBarTabsApiTabSupermenuGroupGroupOfApiReferences {
+          apiGroup
+        }
+      }
+    }
+  }
+  ctaButtons {
+    __typename
+    button1 {
+      __typename
+      label
+      link
+      variant
+    }
+    button2 {
+      __typename
+      label
+      link
+      variant
+    }
+  }
+}
+
+query minimisedNavigationBarFetch($relativePath: String!) {
+  navigationBar(relativePath: $relativePath) {
+    ... on Document {
+      _sys {
+        filename
+        basename
+        hasReferences
+        breadcrumbs
+        path
+        relativePath
+        extension
+      }
+      id
+    }
+    ...MinimisedNavigationBarParts
+  }
+}


### PR DESCRIPTION
As per #221 I have created a new graphQL query called `minimisedNavigationBarFetch` which fetches from a new fragment `MinimisedNavigationBarParts`. This new fragment is the same as the auto-generated just with the body removed. 

<img width="1412" height="1332" alt="image" src="https://github.com/user-attachments/assets/e73f8143-ca84-4b53-a315-9c3b4bbb1af9" />

**Figure: Body removed from items[0].slug**