### PR TITLE
Fix CTA Btn 

### DIFF
--- a/src/components/docs/layout/top-nav.tsx
+++ b/src/components/docs/layout/top-nav.tsx
@@ -61,6 +61,7 @@ export const TopNav = ({
                 {ctaButtons.button1?.label && ctaButtons.button1?.link && (
                   <Link
                     href={ctaButtons.button1.link}
+                    target="_blank"
                     className={`px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${getButtonClasses(
                       ctaButtons.button1.variant
                     )}`}
@@ -71,6 +72,7 @@ export const TopNav = ({
                 {ctaButtons.button2?.label && ctaButtons.button2?.link && (
                   <Link
                     href={ctaButtons.button2.link}
+                    target="_blank"
                     className={`px-4 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${getButtonClasses(
                       ctaButtons.button2.variant
                     )}`}


### PR DESCRIPTION
As per #225, when in TinaCMS admin mode and trying to open external links in the same tab (i.e from the nav bar) the tina editor was trying to render the external link inside the sites content. By specifying that the hyperlink should be opened in a new browsing context we fix this issue (should've been link this anyway for QoL) 