### PR TITLE
Add Media Sync Docs 

### DIFF
--- a/content/docs/going-live/tinacloud/configuring-tinacloud.mdx
+++ b/content/docs/going-live/tinacloud/configuring-tinacloud.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuring TinaCloud
-last_edited: '2025-07-15T06:59:00.339Z'
+last_edited: '2025-08-07T23:37:23.124Z'
+auto_generated: false
 ---
 
 <Callout
@@ -35,6 +36,7 @@ You should now be redirected to the TinaCloud dashboard.
    * **Project Name**: This appears when users log in to the project
    * **Site URL(s)**: Enter both your local URL (e.g., `http://localhost:3000`) and production URL (e.g., `https://yourdomain.com`)
    * **Glob Patterns**: If you're using dynamic preview deployments, you can enter patterns like `https://<PROJECT-NAME>-*-<ACCOUNT-OWNER>.vercel.app`
+4. **Sync Media**: Click on the 'Media' tab and then 'Sync Media'. This will import your media files from your GitHub repository into Tina's Media Manager so they're available in the visual editor.
 
 ## Connecting Your Project to the Editor
 


### PR DESCRIPTION
As per #227 Added docs in the TInaCloud configuration to match the README about Media Sync. 

`Sync Media: Click on the 'Media' tab and then 'Sync Media'. This will import your media files from your GitHub repository into Tina's Media Manager so they're available in the visual editor.`