### PR TITLE
Breadcrumbs

### DIFF
--- a/content/navigation-bar/docs-navigation-bar.json
+++ b/content/navigation-bar/docs-navigation-bar.json
@@ -91,22 +91,6 @@
               "title": "TinaCloud",
               "items": [
                 {
-                  "title": "Group 2",
-                  "items": [
-                    {
-                      "title": "Group 3 ",
-                      "items": [
-                        {
-                          "slug": "content/docs/using-tinacms/usage-developers.mdx",
-                          "_template": "item"
-                        }
-                      ],
-                      "_template": "items"
-                    }
-                  ],
-                  "_template": "items"
-                },
-                {
                   "slug": "content/docs/going-live/tinacloud/what-is-a-datalayer.mdx",
                   "_template": "item"
                 },

--- a/content/navigation-bar/docs-navigation-bar.json
+++ b/content/navigation-bar/docs-navigation-bar.json
@@ -91,6 +91,22 @@
               "title": "TinaCloud",
               "items": [
                 {
+                  "title": "Group 2",
+                  "items": [
+                    {
+                      "title": "Group 3 ",
+                      "items": [
+                        {
+                          "slug": "content/docs/using-tinacms/usage-developers.mdx",
+                          "_template": "item"
+                        }
+                      ],
+                      "_template": "items"
+                    }
+                  ],
+                  "_template": "items"
+                },
+                {
                   "slug": "content/docs/going-live/tinacloud/what-is-a-datalayer.mdx",
                   "_template": "item"
                 },

--- a/src/app/docs/[...slug]/index.tsx
+++ b/src/app/docs/[...slug]/index.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { CopyPageDropdown } from "@/components/copy-page-dropdown";
+import { BreadCrumbs } from "@/components/docs/breadcrumbs";
+import { useNavigation } from "@/components/docs/layout/navigation-context";
 import { OnThisPage } from "@/components/docs/on-this-page";
 import MarkdownComponentMapping from "@/components/tina-markdown/markdown-component-mapping";
 import { Pagination } from "@/components/ui/pagination";
@@ -10,6 +12,8 @@ import { TinaMarkdown } from "tinacms/dist/rich-text";
 
 export default function Document({ props, tinaProps }) {
   const { data } = tinaProps;
+  const navigationData = useNavigation();
+
 
   const documentationData = data.docs;
   const { pageTableOfContents } = props;
@@ -38,6 +42,7 @@ export default function Document({ props, tinaProps }) {
         }`}
       >
         <div className="overflow-hidden break-words mx-8">
+          <BreadCrumbs navigationDocsData={navigationData} />
           <div className="flex flex-col-reverse lg:flex-row lg:items-center justify-between w-full gap-2">
             <h1
               className="text-brand-primary my-4 font-heading text-4xl"

--- a/src/app/docs/[...slug]/index.tsx
+++ b/src/app/docs/[...slug]/index.tsx
@@ -14,7 +14,6 @@ export default function Document({ props, tinaProps }) {
   const { data } = tinaProps;
   const navigationData = useNavigation();
 
-
   const documentationData = data.docs;
   const { pageTableOfContents } = props;
 
@@ -41,9 +40,9 @@ export default function Document({ props, tinaProps }) {
           !documentationData?.tocIsHidden ? "xl:col-span-1" : ""
         }`}
       >
-        <div className="overflow-hidden break-words mx-8">
+        <div className="overflow-hidden break-words mx-8 mt-2 md:mt-0">
           <BreadCrumbs navigationDocsData={navigationData} />
-          <div className="flex flex-col-reverse lg:flex-row lg:items-center justify-between w-full gap-2">
+          <div className="flex flex-row items-center justify-between w-full gap-2">
             <h1
               className="text-brand-primary my-4 font-heading text-4xl"
               data-tina-field={tinaField(documentationData, "title")}

--- a/src/components/copy-page-dropdown.tsx
+++ b/src/components/copy-page-dropdown.tsx
@@ -116,7 +116,7 @@ export const CopyPageDropdown: React.FC<CopyPageDropdownProps> = ({
 
   return (
     <div
-      className="mb-2 inline-flex rounded-lg overflow-hidden lg:mb-0 brand-glass-gradient text-neutral-text-secondary shadow-sm item-center w-fit ml-auto border border-neutral-border-subtle/50"
+      className="mb-2 inline-flex rounded-lg overflow-hidden h-fit lg:mb-0 brand-glass-gradient text-neutral-text-secondary shadow-sm item-center w-fit ml-auto border border-neutral-border-subtle/50"
       data-exclude-from-md
     >
       {/* Primary copy button */}

--- a/src/components/docs/breadcrumbs.tsx
+++ b/src/components/docs/breadcrumbs.tsx
@@ -1,74 +1,147 @@
 "use client";
 
-import { matchActualTarget } from "@/utils/docs/urls";
-import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { usePathname } from "next/navigation";
 import React from "react";
 
-export interface DocsNavProps {
-  navItems: any;
-}
-
-// Helper function to extract a URL string from a slug object (or return it if it's already a string)
-function getUrlFromSlug(slug: any): string {
-  if (typeof slug === "string") return slug;
-  if (slug && typeof slug === "object" && slug.id) {
-    // Transform the id (e.g. "content/docs/introduction/index.mdx") into a URL (e.g. "/docs/introduction/index")
-    return slug.id.replace(/^content\/|\.mdx$/g, "/");
-  }
-  return "";
-}
-
-const getNestedBreadcrumbs = (
-  listItems: any[],
-  pagePath: string,
-  breadcrumbs: any[] = []
-) => {
-  for (const listItem of Array.isArray(listItems) ? listItems : []) {
-    // Get the target URL from the slug (or href) property
-    const target = listItem.slug || listItem.href;
-    const targetUrl = getUrlFromSlug(target);
-    if (matchActualTarget(pagePath, targetUrl)) {
-      breadcrumbs.push(listItem);
-      return [listItem];
+export const BreadCrumbs = ({
+  navigationDocsData,
+}: {
+  navigationDocsData: any;
+}) => {
+  // Helper function to extract a clean URL path from a slug object
+  const getUrlFromSlug = (slug: any): string => {
+    if (typeof slug === "string") return slug;
+    if (slug && typeof slug === "object" && slug._sys?.relativePath) {
+      // Transform relativePath (e.g. "introduction/showcase.mdx") into URL path (e.g. "/docs/introduction/showcase")
+      return `/docs/${slug._sys.relativePath.replace(/\.mdx$/, "")}`;
     }
-    const nestedBreadcrumbs = getNestedBreadcrumbs(
-      listItem.items,
-      pagePath,
-      breadcrumbs
-    );
-    if (nestedBreadcrumbs.length) {
-      return [listItem, ...nestedBreadcrumbs];
+    if (slug && typeof slug === "object" && slug.id) {
+      // Transform id (e.g. "content/docs/introduction/showcase.mdx") into URL path
+      return slug.id.replace(/^content\//, "/").replace(/\.mdx$/, "");
     }
-  }
-  return [];
-};
+    return "";
+  };
 
-export function Breadcrumbs({ navItems }: DocsNavProps) {
-  const pathname = usePathname();
-  const breadcrumbs = getNestedBreadcrumbs(navItems, pathname || "") || [];
+  // Recursive function to search through nested items
+  const searchInItems = (items: any[], currentPath: string): string[] => {
+    if (!Array.isArray(items) || !currentPath) {
+      return [];
+    }
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+
+      if (!item) continue;
+
+      // Check if this item has a slug that matches the current page
+      if (item.slug) {
+        const itemUrl = getUrlFromSlug(item.slug);
+
+        if (
+          itemUrl &&
+          (currentPath === itemUrl || currentPath === itemUrl + "/")
+        ) {
+          const result = [item.slug.title || item.title || "Untitled"];
+          return result;
+        }
+      }
+
+      // If this item has nested items, search recursively
+      if (item.items && Array.isArray(item.items)) {
+        const nestedResult = searchInItems(item.items, currentPath);
+        if (nestedResult.length > 0) {
+          const result = [item.title || "Untitled", ...nestedResult];
+          // Include this item's title in the breadcrumb trail
+          return result;
+        }
+      }
+    }
+
+    return [];
+  };
+
+  // Function to find the breadcrumb trail for the current page
+  const findBreadcrumbTrail = (
+    navigationData: any,
+    currentPath: string
+  ): string[] => {
+    const trail: string[] = [];
+
+    // Defensive checks for invalid data
+    if (
+      !navigationData ||
+      typeof navigationData !== "object" ||
+      !Array.isArray(navigationData.items) ||
+      !currentPath
+    ) {
+      return trail;
+    }
+
+    // Search through supermenu groups (navigationData.items instead of navigationData.content.items)
+    for (let i = 0; i < navigationData.items.length; i++) {
+      const supermenuGroup = navigationData.items[i];
+
+      if (
+        !supermenuGroup ||
+        !supermenuGroup.items ||
+        !Array.isArray(supermenuGroup.items)
+      ) {
+        continue;
+      }
+
+      // Check if the current page exists in this supermenu group
+      const foundInGroup = searchInItems(supermenuGroup.items, currentPath);
+
+      if (foundInGroup.length > 0) {
+        // Add the supermenu group title
+        if (supermenuGroup.title) {
+          trail.push(supermenuGroup.title);
+        }
+        // Add any nested group titles and the final page title
+        trail.push(...foundInGroup);
+        break;
+      }
+    }
+
+    return trail;
+  };
+
+  // Get current pathname using Next.js hook
+  const currentPath = usePathname();
+
+  // Get the breadcrumb trail for the current page
+  const breadcrumbs = findBreadcrumbTrail(navigationDocsData, currentPath);
+
+  if (navigationDocsData) {
+  }
+
+  // Don't render if we don't have valid navigation data or enough breadcrumbs to show
+  if (!navigationDocsData || breadcrumbs.length === 0) {
+    return null;
+  }
 
   return (
-    <ul className="m-0 flex list-none flex-wrap items-center gap-1 p-0">
-      {breadcrumbs.map((breadcrumb, i) => {
-        const url = getUrlFromSlug(breadcrumb.slug);
-        return (
-          <li key={`breadcrumb-${url}-${i}`} className="m-0 flex items-center">
-            {i !== 0 && (
-              <ChevronRightIcon
-                className="mx-2 text-gray-400 size-5"
-                aria-hidden="true"
-              />
+    <nav aria-label="Breadcrumb" className="mb-4">
+      <ol className="flex items-center space-x-2 text-sm text-gray-600">
+        {breadcrumbs.map((crumb, index) => (
+          <li key={index} className="flex items-center">
+            {index > 0 && (
+              <span className="mx-2 text-gray-400" aria-hidden="true">
+                ›
+              </span>
             )}
-            <a
-              href={url}
-              className="text-sm uppercase text-gray-500 transition-opacity duration-150 hover:text-orange-500"
+            <span
+              className={`${
+                index === breadcrumbs.length - 1
+                  ? "font-medium text-gray-900"
+                  : "text-gray-500"
+              } uppercase tracking-wide`}
             >
-              {breadcrumb.title || breadcrumb.category}
-            </a>
+              {crumb}
+            </span>
           </li>
-        );
-      })}
-    </ul>
+        ))}
+      </ol>
+    </nav>
   );
-}
+};

--- a/src/components/docs/breadcrumbs.tsx
+++ b/src/components/docs/breadcrumbs.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 interface BreadcrumbItem {
   title: string;
-  url?: string; 
+  url?: string;
 }
 
 export const BreadCrumbs = ({
@@ -16,11 +16,25 @@ export const BreadCrumbs = ({
 }) => {
   // Helper function to extract a clean URL path from a slug object
   const getUrlFromSlug = (slug: any): string => {
-    if (typeof slug === "string") return slug;
+    if (typeof slug === "string") {
+      // Handle special case for docs homepage
+      if (slug === "content/docs/index.mdx") {
+        return "/docs";
+      }
+      return slug;
+    }
     if (slug && typeof slug === "object" && slug._sys?.relativePath) {
+      // Handle special case for docs homepage
+      if (slug._sys.relativePath === "index.mdx") {
+        return "/docs";
+      }
       return `/docs/${slug._sys.relativePath.replace(/\.mdx$/, "")}`;
     }
     if (slug && typeof slug === "object" && slug.id) {
+      // Handle special case for docs homepage
+      if (slug.id === "content/docs/index.mdx") {
+        return "/docs";
+      }
       return slug.id.replace(/^content\//, "/").replace(/\.mdx$/, "");
     }
     return "";
@@ -47,7 +61,10 @@ export const BreadCrumbs = ({
   };
 
   // Recursive function to search through nested items and return breadcrumb items
-  const searchInItems = (items: any[], currentPath: string): BreadcrumbItem[] => {
+  const searchInItems = (
+    items: any[],
+    currentPath: string
+  ): BreadcrumbItem[] => {
     if (!Array.isArray(items) || !currentPath) return [];
 
     for (const item of items) {
@@ -56,9 +73,15 @@ export const BreadCrumbs = ({
       // Check if this item has a slug that matches the current page
       if (item.slug) {
         const itemUrl = getUrlFromSlug(item.slug);
-        if (itemUrl && (currentPath === itemUrl || currentPath === itemUrl + "/")) {
-          // This is the current page - no URL needed
-          return [{ title: item.slug.title || item.title || "Untitled" }];
+        if (itemUrl) {
+          // Normalize URLs for comparison (remove trailing slashes)
+          const normalizedCurrentPath = currentPath.replace(/\/$/, "") || "/";
+          const normalizedItemUrl = itemUrl.replace(/\/$/, "") || "/";
+
+          if (normalizedCurrentPath === normalizedItemUrl) {
+            // This is the current page - no URL needed
+            return [{ title: item.slug.title || item.title || "Untitled" }];
+          }
         }
       }
 
@@ -70,11 +93,11 @@ export const BreadCrumbs = ({
           // Add this item's title with a link to its first page
           const firstPageUrl = findFirstPageUrl(item.items);
           return [
-            { 
-              title: item.title || "Untitled", 
-              url: firstPageUrl || undefined 
+            {
+              title: item.title || "Untitled",
+              url: firstPageUrl || undefined,
             },
-            ...nestedResult
+            ...nestedResult,
           ];
         }
       }
@@ -118,7 +141,7 @@ export const BreadCrumbs = ({
           const firstPageUrl = findFirstPageUrl(supermenuGroup.items);
           trail.push({
             title: supermenuGroup.title,
-            url: firstPageUrl || undefined
+            url: firstPageUrl || undefined,
           });
         }
         // Add any nested group titles and the final page title
@@ -151,7 +174,7 @@ export const BreadCrumbs = ({
                   ›
                 </span>
               )}
-              
+
               {isClickable ? (
                 <Link
                   href={crumb.url!}

--- a/src/components/docs/breadcrumbs.tsx
+++ b/src/components/docs/breadcrumbs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { usePathname } from "next/navigation";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import React from "react";
 
 interface BreadcrumbItem {
@@ -188,7 +188,7 @@ export const BreadCrumbs = ({
 
               {isClickable ? (
                 <Link
-                  href={crumb.url!}
+                  href={crumb?.url || "/"}
                   className="text-sm uppercase text-neutral-text-secondary hover:text-brand-primary transition-all duration-300 cursor-pointer"
                 >
                   {crumb.title}

--- a/src/components/docs/breadcrumbs.tsx
+++ b/src/components/docs/breadcrumbs.tsx
@@ -165,10 +165,7 @@ export const BreadCrumbs = ({
 
   const currentPath = usePathname();
 
-
   const breadcrumbs = findBreadcrumbTrail(navigationDocsData, currentPath);
-
-  
 
   if (!navigationDocsData || breadcrumbs.length === 0) {
     return null;

--- a/src/components/docs/layout/body.tsx
+++ b/src/components/docs/layout/body.tsx
@@ -1,5 +1,3 @@
-import { BreadCrumbs } from "@/components/docs/breadcrumbs";
-
 export const Body = ({
   navigationDocsData,
   children,
@@ -9,7 +7,6 @@ export const Body = ({
 }) => {
   return (
     <>
-      <BreadCrumbs navigationDocsData={navigationDocsData} />
       <div data-pagefind-body id="doc-content">
         {children}
       </div>

--- a/src/components/docs/layout/body.tsx
+++ b/src/components/docs/layout/body.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumbs } from "@/components/docs/breadcrumbs";
+import { BreadCrumbs } from "@/components/docs/breadcrumbs";
 
 export const Body = ({
   navigationDocsData,
@@ -9,7 +9,7 @@ export const Body = ({
 }) => {
   return (
     <>
-      <Breadcrumbs navItems={navigationDocsData} />
+      <BreadCrumbs navigationDocsData={navigationDocsData} />
       <div data-pagefind-body id="doc-content">
         {children}
       </div>

--- a/src/components/docs/layout/tab-layout.tsx
+++ b/src/components/docs/layout/tab-layout.tsx
@@ -39,7 +39,7 @@ export const TabsLayout = ({
     }));
     setTabs(tabs);
     setSelectedTab(tabs[0]);
-    setObjectOfSelectedTab(tabs[0])
+    setObjectOfSelectedTab(tabs[0]);
   }, [tinaProps.data]);
 
   React.useEffect(() => {
@@ -78,7 +78,10 @@ export const TabsLayout = ({
           <Sidebar tabs={tabs} />
           <main className="flex-1">
             {selectedTab && (
-              <Body navigationDocsData={objectOfSelectedTab?.content} children={children} />
+              <Body
+                navigationDocsData={objectOfSelectedTab?.content}
+                children={children}
+              />
             )}
           </main>
         </div>

--- a/src/components/docs/layout/tab-layout.tsx
+++ b/src/components/docs/layout/tab-layout.tsx
@@ -23,6 +23,7 @@ export const TabsLayout = ({
   const [navigationDocsData, setNavigationDocsData] = React.useState({});
   const [tabs, setTabs] = React.useState([]);
   const [selectedTab, setSelectedTab] = React.useState();
+  const [objectOfSelectedTab, setObjectOfSelectedTab] = React.useState();
   const pathname = usePathname();
 
   React.useEffect(() => {
@@ -38,6 +39,7 @@ export const TabsLayout = ({
     }));
     setTabs(tabs);
     setSelectedTab(tabs[0]);
+    setObjectOfSelectedTab(tabs[0])
   }, [tinaProps.data]);
 
   React.useEffect(() => {
@@ -57,6 +59,7 @@ export const TabsLayout = ({
 
   const handleTabChange = (value: string) => {
     setSelectedTab(value);
+    setObjectOfSelectedTab(value);
     const newIndex = tabs.findIndex((tab) => tab.label === value);
     window.dispatchEvent(
       new CustomEvent("tabChange", { detail: { value: newIndex.toString() } })
@@ -74,7 +77,9 @@ export const TabsLayout = ({
         <div className="w-full flex flex-col md:flex-row gap-4 md:p-4 max-w-[2560px] mx-auto">
           <Sidebar tabs={tabs} />
           <main className="flex-1">
-            <Body navigationDocsData={tabs} children={children} />
+            {selectedTab && (
+              <Body navigationDocsData={objectOfSelectedTab?.content} children={children} />
+            )}
           </main>
         </div>
       </NavigationProvider>

--- a/tina/templates/submenu.template.tsx
+++ b/tina/templates/submenu.template.tsx
@@ -1,12 +1,12 @@
 import type { Template } from "tinacms";
 import { itemTemplate } from "./navbar-ui.template";
 
-const createMenuTemplate = (templates: Template[]): Template => ({
+const createMenuTemplate = (templates: Template[], level: number): Template => ({
   label: "Submenu",
   name: "items",
   ui: {
     itemProps: (item) => {
-      return { label: `🗂️ ${item?.title ?? "Unnamed Menu Group"}` };
+      return { label: `🗂️ ${level} | ${item?.title ?? "Unnamed Menu Group"}` };
     },
   },
   fields: [
@@ -21,14 +21,14 @@ const createMenuTemplate = (templates: Template[]): Template => ({
   ],
 });
 
-const thirdLevelSubmenu: Template = createMenuTemplate([itemTemplate]);
+const thirdLevelSubmenu: Template = createMenuTemplate([itemTemplate], 3);
 const secondLevelSubmenu: Template = createMenuTemplate([
   thirdLevelSubmenu,
   itemTemplate,
-]);
+], 2);
 export const submenuTemplate: Template = createMenuTemplate([
   secondLevelSubmenu,
   itemTemplate,
-]);
+], 1  );
 
 export default submenuTemplate;

--- a/tina/templates/submenu.template.tsx
+++ b/tina/templates/submenu.template.tsx
@@ -1,7 +1,10 @@
 import type { Template } from "tinacms";
 import { itemTemplate } from "./navbar-ui.template";
 
-const createMenuTemplate = (templates: Template[], level: number): Template => ({
+const createMenuTemplate = (
+  templates: Template[],
+  level: number
+): Template => ({
   label: "Submenu",
   name: "items",
   ui: {
@@ -22,13 +25,13 @@ const createMenuTemplate = (templates: Template[], level: number): Template => (
 });
 
 const thirdLevelSubmenu: Template = createMenuTemplate([itemTemplate], 3);
-const secondLevelSubmenu: Template = createMenuTemplate([
-  thirdLevelSubmenu,
-  itemTemplate,
-], 2);
-export const submenuTemplate: Template = createMenuTemplate([
-  secondLevelSubmenu,
-  itemTemplate,
-], 1  );
+const secondLevelSubmenu: Template = createMenuTemplate(
+  [thirdLevelSubmenu, itemTemplate],
+  2
+);
+export const submenuTemplate: Template = createMenuTemplate(
+  [secondLevelSubmenu, itemTemplate],
+  1
+);
 
 export default submenuTemplate;


### PR DESCRIPTION
As per #232 we have added breadcrumbs to the tina-docs starter package 

<img width="1139" height="904" alt="Screenshot 2025-08-08 at 2 51 42 pm" src="https://github.com/user-attachments/assets/fd890e08-e948-4dec-86d5-08f5952846ee" />

The breadcrumbs are links that take you to the first item of that section