### PR TITLE
Updating GitHub action for Chromium Search Tests

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Slugify branch name
         id: slug
         run: |
-          SLUG=$(echo "${{ github.head_ref }}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          SLUG=$(echo "${{ github.head_ref }}" | tr '/' '-' | tr -d '.' | tr '[:upper:]' '[:lower:]')
           echo "slug=$SLUG" >> $GITHUB_OUTPUT
 
   search-tests:


### PR DESCRIPTION
## Summary
🐛 is that the tests try and create the vercel staging deployment urls from the branch name, but doesn't strip out periods (.)

The real vercel staging deployment urls strip them out, which causes the tests to fail.

This fixes the generation logic.