### PR TITLE
🔍 Build Pagefind index on first dev run when it's missing

### DIFF
--- a/scripts/check-pagefind.js
+++ b/scripts/check-pagefind.js
@@ -1,13 +1,15 @@
 const fs = require("fs");
 const path = require("path");
+const { execSync } = require("child_process");
 
 const entryPath = path.join(__dirname, "..", "public", "pagefind", "pagefind-entry.json");
 
 if (!fs.existsSync(entryPath)) {
-  console.warn(
-    "\x1b[33m⚠  Pagefind index not found. Search will not work in dev.\n" +
-    "   Run: pnpm build-local-pagefind\x1b[0m\n"
+  console.log(
+    "\x1b[33mPagefind index not found — building it now from your content.\n" +
+    "   (First run only; this does a full build and can take a minute or two.)\x1b[0m\n"
   );
+  execSync("pnpm build-local-pagefind", { stdio: "inherit" });
   process.exit(0);
 }
 


### PR DESCRIPTION
## TL;DR

Search silently breaks in dev when the Pagefind index is absent — `predev` only printed a warning telling the user to run `build-local-pagefind` themselves. This builds the index automatically on the first dev run instead.

## How

`scripts/check-pagefind.js`: when `pagefind-entry.json` is missing, run `pnpm build-local-pagefind` (a full build + index) instead of just warning. The staleness-age warning for an existing index is unchanged.

## Reviewer notes

- **First run only.** Once the index exists, this path is skipped, so normal `pnpm dev` is unaffected.