### PR TITLE
🔍 Fix Chromium search by loading Pagefind without eval

### DIFF
--- a/src/components/search-docs/search.tsx
+++ b/src/components/search-docs/search.tsx
@@ -52,15 +52,25 @@ export function Search({ className }: { className?: string }) {
       if (typeof window !== "undefined") {
         let pagefindModule: any;
         try {
-          // Using eval to import pagefind.js is a workaround since the script isn't available during the build process.
-          // This also improves performance by loading the script only when needed, reducing initial page load time.
-          // A direct import would require committing the file with the codebase, which would change frequently
-          // with every content update.
+          // pagefind.js is generated at build time and lives outside the bundle. The
+          // webpackIgnore/turbopackIgnore comments tell both bundlers to leave this dynamic
+          // import alone (the reason the old code resorted to `window.eval`), emitting it as a
+          // runtime import. Avoiding `eval` means no CSP 'unsafe-eval' is required, which is
+          // what was breaking search under Chromium's stricter enforcement.
+          const pagefindUrl = new URL(
+            `${pagefindPath}/pagefind.js`,
+            window.location.origin
+          ).href;
 
-          pagefindModule = await (window as any).eval(
-            `import("${pagefindPath}/pagefind.js")`
+          pagefindModule = await import(
+            /* webpackIgnore: true */
+            /* turbopackIgnore: true */
+            pagefindUrl
           );
         } catch (importError) {
+          // Surface the real cause (CSP, MIME type, or 404) instead of swallowing it.
+          // biome-ignore lint/suspicious/noConsole: needed to diagnose load failures in prod
+          console.error("Pagefind failed to load:", importError);
           setError(
             "Unable to load search functionality. For more information, please check this README: https://github.com/tinacms/tina-docs?tab=readme-ov-file#search-functionality and refresh the page."
           );


### PR DESCRIPTION
## TL;DR

Search silently failed in Chromium because `pagefind.js` was loaded via `window.eval("import(...)")`, which Chromium blocks without CSP `'unsafe-eval'` — and the real error was swallowed, leaving only a generic banner. This replaces the eval with a real bundler-ignored dynamic import and logs the underlying error.

## How

Drop `window.eval("import(...)")` for `await import(/* webpackIgnore */ /* turbopackIgnore */ url)` with an origin-qualified URL. No `eval` means no `'unsafe-eval'` requirement; the ignore comments are what the eval was hacking around — they keep the bundler from resolving the runtime-only `pagefind.js`. The catch now logs the real error instead of discarding it.

## Reviewer notes

- **WASM CSP caveat.** Pagefind uses WebAssembly; a strict CSP could still need `'wasm-unsafe-eval'`. With the error now logged, that case is diagnosable instead of silent.

## Tests

Verified in dev Chromium (Playwright): typing in the search box loads `pagefind.js` and returns real results with no error banner. Biome passes on `search.tsx`.